### PR TITLE
adjustment DISCOVERY_INTERVAL

### DIFF
--- a/custom_components/tuya_custom/tuyaha/tuyaapi.py
+++ b/custom_components/tuya_custom/tuyaha/tuyaapi.py
@@ -13,8 +13,8 @@ from .devices.factory import get_tuya_device
 TUYACLOUDURL = "https://px1.tuya{}.com"
 DEFAULTREGION = "us"
 
-MIN_DISCOVERY_INTERVAL = 60
-MAX_DISCOVERY_INTERVAL = 130
+MIN_DISCOVERY_INTERVAL = 15
+MAX_DISCOVERY_INTERVAL = 45
 REFRESHTIME = 60 * 60 * 12
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
As far as I have verified, it seems that the reception interval of API
does not increase even if a FrequentlyInvoke error appears. Therefore,
even if an error occurred, I thought that the UX would improve by
proactively sending requests.