### PR TITLE
Color mode support

### DIFF
--- a/custom_components/tuya_custom/tuyaha/devices/light.py
+++ b/custom_components/tuya_custom/tuyaha/devices/light.py
@@ -1,6 +1,5 @@
 from .base import TuyaDevice
 
-
 class TuyaLight(TuyaDevice):
 
     def brightness(self):
@@ -35,7 +34,6 @@ class TuyaLight(TuyaDevice):
             work_mode = self.data.get("color_mode")
             color = self.data.get("color")
             if work_mode == "colour" and color:
-                color = self.data.get("color")
                 return color.get("hue"), color.get("saturation")
             else:
                 return 0.0, 0.0
@@ -82,7 +80,6 @@ class TuyaLight(TuyaDevice):
             hsv_color["hue"] = 0
         if self._control_device("colorSet", {"color": hsv_color}):
             self._update_data("color", hsv_color)
-            self._update_data("color_mode", "white" if hsv_color["saturation"] == 0 else "colour")
 
     def set_color_temp(self, color_temp):
         if self._control_device("colorTemperatureSet", {"value": color_temp}):

--- a/custom_components/tuya_custom/tuyaha/devices/light.py
+++ b/custom_components/tuya_custom/tuyaha/devices/light.py
@@ -1,5 +1,9 @@
 from .base import TuyaDevice
 
+"""The minimum brightness value set in the API that does not turn off the light."""
+MIN_BRIGHTNESS_VAL = 10.3
+MIN_BRIGHTNESS = 255 * MIN_BRIGHTNESS_VAL / 100
+
 class TuyaLight(TuyaDevice):
 
     def brightness(self):
@@ -7,7 +11,9 @@ class TuyaLight(TuyaDevice):
         if work_mode == "colour" and "color" in self.data:
             brightness = int(self.data.get("color").get("brightness") * 255 / 100)
         else:
-            brightness = self.data.get("brightness")
+            brightness = int(self.data.get("brightness"))
+        """Rescale with MIN_BRIGHTNESS as "1"."""
+        brightness = min(int(max((brightness - MIN_BRIGHTNESS), 1) / (255 - MIN_BRIGHTNESS) * 255), 255)
         return brightness
 
     def _set_brightness(self, brightness):
@@ -62,7 +68,12 @@ class TuyaLight(TuyaDevice):
 
     def set_brightness(self, brightness):
         """Set the brightness(0-255) of light."""
-        value = int(brightness * 100 / 255)
+        if (int(brightness) > 0):
+            """Restore the value rescaled with MIN_BRIGHTNESS."""
+            brightness = min(max(int(brightness / 255 * (255 - MIN_BRIGHTNESS) + MIN_BRIGHTNESS), MIN_BRIGHTNESS), 255)
+            value = max(brightness * 100 / 255.0, MIN_BRIGHTNESS_VAL)
+        else:
+            brightness = value = 0
         if self._control_device("brightnessSet", {"value": value}):
             self._update_data("brightness", brightness)
 

--- a/custom_components/tuya_custom/tuyaha/devices/light.py
+++ b/custom_components/tuya_custom/tuyaha/devices/light.py
@@ -19,10 +19,10 @@ class TuyaLight(TuyaDevice):
             self.data["brightness"] = brightness
 
     def support_color(self):
-        if self.data.get("color") is None:
-            return False
-        else:
+        if self.data.get("color") or self.data.get("color_mode") == "colour":
             return True
+        else:
+            return False
 
     def support_color_temp(self):
         if self.data.get("color_temp") is None:
@@ -31,15 +31,16 @@ class TuyaLight(TuyaDevice):
             return True
 
     def hs_color(self):
-        if self.data.get("color") is None:
-            return None
-        else:
+        if self.data.get("color") or self.data.get("color_mode") == "colour":
             work_mode = self.data.get("color_mode")
-            if work_mode == "colour":
+            color = self.data.get("color")
+            if work_mode == "colour" and color:
                 color = self.data.get("color")
                 return color.get("hue"), color.get("saturation")
             else:
                 return 0.0, 0.0
+        else:
+            return None
 
     def color_temp(self):
         if self.data.get("color_temp") is None:


### PR DESCRIPTION
Supports color mode. However, since the color mode parameter cannot be obtained from the Tuya API, there are the following restrictions.

- White mode bulbs cannot be changed to color mode in HA
- It is necessary to set the light bulb to color mode using the SmartLife app.
- Color mode parameters set in the SmartLife app etc. are not reflected in HA.

You can:
- Color mode bulbs can be parameterized with HA.